### PR TITLE
Add includedPrimaryTypes Support to usePlacesAutocomplete

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -219,6 +219,38 @@ describe('usePlacesAutocomplete', () => {
     expect(result.current.error).toBeNull();
   });
 
+  it('should include includedPrimaryTypes in the request body when provided', async () => {
+    const includedPrimaryTypes = ['locality', 'sublocality'];
+
+    const mockFetch = vi.fn().mockImplementation((_url: string, options: any) => {
+      const body = JSON.parse(options.body);
+      expect(body.includedPrimaryTypes).toEqual(includedPrimaryTypes);
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ suggestions: [] }),
+      });
+    });
+    // @ts-ignore
+    global.fetch = mockFetch;
+
+    const { result } = renderHook(() =>
+      usePlacesAutocomplete({ apiKey: mockApiKey, includedPrimaryTypes }),
+    );
+
+    act(() => {
+      result.current.setValue('test');
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(300);
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining('https://places.googleapis.com/v1/places:autocomplete'),
+      expect.any(Object),
+    );
+  });
+
   it('should handle network errors', async () => {
     const mockFetch = vi.fn().mockRejectedValue(new TypeError('Network error'));
     global.fetch = mockFetch;

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ export function usePlacesAutocomplete({
   debounceMs = 300,
   language = 'en',
   types,
+  includedPrimaryTypes,
   sessionToken,
   location,
   setSelectedPlace,
@@ -107,6 +108,10 @@ export function usePlacesAutocomplete({
           requestBody.types = types;
         }
 
+        if (includedPrimaryTypes) {
+          requestBody.includedPrimaryTypes = includedPrimaryTypes;
+        }
+
         if (location) {
           requestBody.locationBias = {
             circle: {
@@ -147,7 +152,7 @@ export function usePlacesAutocomplete({
         setLoading(false);
       }
     },
-    [apiKey, language, sessionToken, types, location, clear],
+    [apiKey, language, sessionToken, types, includedPrimaryTypes, location, clear],
   );
 
   const debouncedSearch = useCallback(

--- a/src/types.ts
+++ b/src/types.ts
@@ -50,6 +50,7 @@ export interface UsePlacesAutocompleteOptions {
   debounceMs?: number;
   language?: string;
   types?: string[];
+  includedPrimaryTypes?: string[];
   sessionToken?: string;
   location?: {
     lat: number;


### PR DESCRIPTION
Description:
This PR adds support for the [includedPrimaryTypes](https://developers.google.com/maps/documentation/places/web-service/place-autocomplete#includedPrimaryTypes) parameter in usePlacesAutocomplete. This allows developers to filter results by primary place types supported by the Places API (e.g., "(cities)", "locality", "airport"), enabling more precise autocomplete suggestions.

Changes:

Added an optional includedPrimaryTypes?: string[] parameter to the hook configuration.

Updated the request body in search to include:

```
if (includedPrimaryTypes?.length) {
  requestBody.includedPrimaryTypes = includedPrimaryTypes;
}
```
Maintained backward compatibility — existing types parameter usage is unaffected.

Why:
The includedPrimaryTypes parameter is part of the newer Places Autocomplete API and is the recommended way to filter predictions by category. Including it in this library improves developer experience and aligns with Google’s official API design.