### PR TITLE
Update session token usage to match Google docs

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -692,10 +692,10 @@ describe('usePlacesAutocomplete', () => {
 
   it('should handle session token in headers', async () => {
     const sessionToken = 'test-session-token';
-    let requestHeaders: any;
+    let requestBody: any;
 
     const mockFetch = vi.fn().mockImplementation((_url: string, options: any) => {
-      requestHeaders = options.headers;
+      requestBody = JSON.parse(options.body);
       return Promise.resolve({
         ok: true,
         json: () => Promise.resolve({ suggestions: [] }),
@@ -715,15 +715,16 @@ describe('usePlacesAutocomplete', () => {
       vi.advanceTimersByTime(300);
     });
 
-    expect(requestHeaders['X-Goog-Api-Key']).toBe(mockApiKey);
+    expect(requestBody.sessionToken).toBeDefined();
+    expect(requestBody.sessionToken).toBe(sessionToken);
   });
 
   it('should handle session token in getPlaceDetails headers', async () => {
     const sessionToken = 'test-session-token';
-    let requestHeaders: any;
+    let requestUrl: any;
 
-    const mockFetch = vi.fn().mockImplementation((_url: string, options: any) => {
-      requestHeaders = options.headers;
+    const mockFetch = vi.fn().mockImplementation((_url: string) => {
+      requestUrl = _url;
       return Promise.resolve({
         ok: true,
         json: () =>
@@ -744,7 +745,7 @@ describe('usePlacesAutocomplete', () => {
       await result.current.getPlaceDetails('1');
     });
 
-    expect(requestHeaders['X-Goog-Api-Key']).toBe(mockApiKey);
+    expect(requestUrl).toContain(`sessionToken=${sessionToken}`);
   });
 
   it('should handle debounced search with custom debounce time', async () => {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -690,7 +690,7 @@ describe('usePlacesAutocomplete', () => {
     expect(requestBody.includedRegionCodes).toEqual(['US', 'CA']);
   });
 
-  it('should handle session token in headers', async () => {
+  it('should include session token in request body', async () => {
     const sessionToken = 'test-session-token';
     let requestBody: any;
 
@@ -719,7 +719,7 @@ describe('usePlacesAutocomplete', () => {
     expect(requestBody.sessionToken).toBe(sessionToken);
   });
 
-  it('should handle session token in getPlaceDetails headers', async () => {
+  it('should include session token in getPlaceDetails query params', async () => {
     const sessionToken = 'test-session-token';
     let requestUrl: any;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,13 +44,12 @@ export function usePlacesAutocomplete({
         const fieldMask = fields && fields.length > 0 ? fields.join(',') : defaultFields.join(',');
 
         const response = await fetch(
-          `https://places.googleapis.com/v1/places/${placeId}?key=${apiKey}&languageCode=${language}`,
+          `https://places.googleapis.com/v1/places/${placeId}?key=${apiKey}&languageCode=${language}${sessionToken ? `&sessionToken=${sessionToken}` : ''}`,
           {
             method: 'GET',
             headers: {
               'Content-Type': 'application/json',
               'X-Goog-FieldMask': fieldMask,
-              ...(sessionToken && { 'X-Goog-Api-Key': apiKey }),
             },
           },
         );
@@ -132,6 +131,10 @@ export function usePlacesAutocomplete({
           requestBody.includeQueryPredictions = true;
         }
 
+        if (sessionToken) {
+          requestBody.sessionToken = sessionToken;
+        }
+
         const response = await fetch(
           `https://places.googleapis.com/v1/places:autocomplete?key=${apiKey}`,
           {
@@ -140,7 +143,6 @@ export function usePlacesAutocomplete({
               'Content-Type': 'application/json',
               'X-Goog-FieldMask':
                 'suggestions.placePrediction.place,suggestions.placePrediction.placeId,suggestions.placePrediction.text,suggestions.placePrediction.structuredFormat,suggestions.placePrediction.types',
-              ...(sessionToken && { 'X-Goog-Api-Key': apiKey }),
             },
             body: JSON.stringify(requestBody),
           },


### PR DESCRIPTION
These changes move `sessionToken` to the POST body for autocomplete requests, and to the query string when fetching place details. 

Following the documentation here https://developers.google.com/maps/documentation/places/web-service/using-session-tokens